### PR TITLE
Add ShareTournament component and integrate it into Home

### DIFF
--- a/components/Home.tsx
+++ b/components/Home.tsx
@@ -4,6 +4,7 @@ import CourtSettings from '@/components/CourtSettings';
 import MatchDraw from '@/components/MatchDraw';
 import PlayerRegistration from '@/components/PlayerRegistration';
 import ResetTournament from '@/components/ResetTournament';
+import ShareTournament from '@/components/ShareTournament';
 import TournamentBracket from '@/components/TournamentBracket';
 import { TournamentManager } from '@/components/TournamentManager';
 import TournamentTable from '@/components/TournamentTable';
@@ -26,7 +27,12 @@ export default function Home() {
           />
           <h1 className="text-2xl sm:text-4xl font-bold">Presença Open</h1>
         </div>
-        {tournamentId && <ResetTournament />}
+        {tournamentId && (
+          <div className="flex items-center gap-2">
+            <ShareTournament />
+            <ResetTournament />
+          </div>
+        )}
       </div>
 
       <div className="grid gap-4 sm:gap-8">

--- a/components/ShareTournament.tsx
+++ b/components/ShareTournament.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useTournament } from '@/contexts/TournamentContext';
+import { CheckIcon, Copy } from 'lucide-react';
+import { useState } from 'react';
+
+export default function ShareTournament() {
+  const { tournamentId } = useTournament();
+  const [copied, setCopied] = useState(false);
+
+  if (!tournamentId) {
+    return null;
+  }
+
+  const handleShare = async () => {
+    const baseUrl = window.location.origin;
+    const shareUrl = `${baseUrl}?tournament=${tournamentId}`;
+
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error('Failed to copy URL:', error);
+      // Fallback for browsers that don't support clipboard API
+      const textArea = document.createElement('textarea');
+      textArea.value = shareUrl;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const copiedText = (
+    <>
+      <CheckIcon className="h-4 w-4 mr-2" />
+      Copiado!
+    </>
+  );
+  const shareText = (
+    <>
+      <Copy className="h-4 w-4 mr-2" />
+      Compartilhar
+    </>
+  );
+
+  return (
+    <Button
+      onClick={handleShare}
+      variant="outline"
+      size="sm"
+      className="text-sm"
+    >
+      {copied ? copiedText : shareText}
+    </Button>
+  );
+}

--- a/lib/useTournamentId.ts
+++ b/lib/useTournamentId.ts
@@ -1,13 +1,27 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 export function useTournamentId() {
   const [tournamentId, setTournamentId] = useState<string | null>(null);
 
   useEffect(() => {
-    // Carrega do localStorage
-    const savedTournamentId = localStorage.getItem('current-tournament-id');
-    if (savedTournamentId) {
-      setTournamentId(savedTournamentId);
+    // First, check URL parameters
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlTournamentId = urlParams.get('tournament');
+
+    if (urlTournamentId) {
+      setTournamentId(urlTournamentId);
+      // Also save to localStorage for future visits
+      localStorage.setItem('current-tournament-id', urlTournamentId);
+      // Update URL to remove the parameter (clean URL)
+      const newUrl = new URL(window.location.href);
+      newUrl.searchParams.delete('tournament');
+      window.history.replaceState({}, '', newUrl.toString());
+    } else {
+      // If no URL parameter, fall back to localStorage
+      const savedTournamentId = localStorage.getItem('current-tournament-id');
+      if (savedTournamentId) {
+        setTournamentId(savedTournamentId);
+      }
     }
   }, []);
 
@@ -22,6 +36,6 @@ export function useTournamentId() {
 
   return {
     tournamentId,
-    setCurrentTournament
+    setCurrentTournament,
   };
-} 
+}


### PR DESCRIPTION
- Introduced ShareTournament component for sharing tournament links via clipboard.
- Updated Home component to include ShareTournament alongside ResetTournament, enhancing user interaction.
- Refactored useTournamentId hook to prioritize URL parameters for tournament ID retrieval, improving user experience and URL management.